### PR TITLE
Update documentation around Table Converter

### DIFF
--- a/R/NP-utils.R
+++ b/R/NP-utils.R
@@ -1,6 +1,14 @@
 # series of utility functions for calling nutrientprofiler functions
 library(nutrientprofiler)
 
+#' Run Nutrient Profiler
+#'
+#' This function runs the nutrientprofiler pipeline
+#' on all values in the passed data.frame.
+#'
+#' @param dataframe, R data.frame for nutrientprofiler functions
+#' @returns an R data.frame with input columns and
+#' nutrientprofiler columns added
 runNP <- function(dataframe) {
     stopifnot("Expected a data.frame type to be passed" = 
     is.data.frame(dataframe))

--- a/R/bulk-upload-server.R
+++ b/R/bulk-upload-server.R
@@ -1,6 +1,16 @@
 library(shiny)
 library(readxl)
 
+#' Load data function
+#' 
+#' This function accepts a shiny InputFile list
+#' it extracts the file extension using the `extract_ext`
+#' utility function from the $datapath value and 
+#' then tries to load the data using either read.csv or readxl
+#' it returns the dataframe otherwise catches an error.
+#' It does so safely to help pass this up to the Shiny app
+#' @param file, a Shiny InputFile list
+#' @returns a dataframe
 load_and_render <- function(file) {
 
             # retrieve file extension

--- a/R/bulk-upload-ui.R
+++ b/R/bulk-upload-ui.R
@@ -2,6 +2,7 @@
 library(shiny)
 library(DT)
 
+# define a tabPanel for introducing the NPM Table calculator
 introTab <- tabPanel(
   title = tags$b("NPM Table Calculator"),
   value = "bulkDataDesc",
@@ -37,6 +38,8 @@ introTab <- tabPanel(
   small preview table of your data showing the result of the NPM 
   calculation. You will also be able to download your dataset as a CSV file
   with additional columns generated during the assessment step."),
+  # a centered row that contains anchors for downloading
+  # template data files
   fluidRow(style = "text-align:center;",
     column(12,
           a(href="example-NPM-data.xlsx", 
@@ -51,6 +54,7 @@ introTab <- tabPanel(
           class="btn btn-primary")
         ),
       ),
+      # row containing button to move to next tab
       fluidRow(style = "margin: 1.5%; text-align:center;",
         column(12,
               actionButton('moveBulkTab', "Next", icon = icon("nutritionix"),
@@ -61,6 +65,7 @@ introTab <- tabPanel(
       )
 
 
+# define a tabPanel for the uploading data tab
 tableTab <- tabPanel(
     title = tags$b("Upload data"),
     value = "bulkDataUpload",
@@ -97,7 +102,7 @@ tableTab <- tabPanel(
 )
 
 
-
+# define a tabPanel for the results of running the nutrient profiler pipeline
 resultTab <- tabPanel(tags$b("Results"), value = "bulkResult",
                       h3("Results"),
                       p("See below for the NPM calculator results on your dataset. 
@@ -111,7 +116,8 @@ resultTab <- tabPanel(tags$b("Results"), value = "bulkResult",
                       )
 
 # the main tab constructor
-
+# this variable contructs the full tab panel from
+# all other tabs defined above
 bulkTab <- tabPanel("Table Calculator",
                     value = "bulkCalc",
                     tabsetPanel(type = "tabs", 

--- a/README.md
+++ b/README.md
@@ -3,3 +3,31 @@
 [![DOI](https://zenodo.org/badge/525283616.svg)](https://zenodo.org/badge/latestdoi/525283616)
 
 First release of the NPM Calculator tool. This version is designed to assess user-entered single product information against the [UK NPM (2004/5)](https://www.gov.uk/government/publications/the-nutrient-profiling-model) and scope for [HFSS legislation](https://www.gov.uk/government/publications/restricting-promotions-of-products-high-in-fat-sugar-or-salt-by-location-and-by-volume-price/restricting-promotions-of-products-high-in-fat-sugar-or-salt-by-location-and-by-volume-price-implementation-guidance) around product placement.
+
+## NPM Table Calculator
+
+This package also includes an experimental Table Calculator feature. 
+This uses the CDRC R package
+[`nutrientprofiler`](https://github.com/Leeds-CDRC/nutrientprofiler)
+which is explicitly installed in the [Dockerfile](./Dockerfile). All components
+of the Table Calculator except server functions are defined within new component
+files that are present in the [`R`](./R/) folder. All server functions for the
+Table Calculator are defined within [server.R](./server.R#L509) to enable proper
+propogration of input and output variables.
+
+### Updating `nutrientprofiler` package in NPM Calculator
+
+Occasionally, there may be updates to the
+[`nutrientprofiler`](https://github.com/Leeds-CDRC/nutrientprofiler) package
+that need to be updated within this Shiny app. To pull through more up to date
+versions of the package you should change the version specified within the `RUN`
+line that installs the package within the [Dockerfile](./Dockerfile#L5).
+
+```docker
+# change @v1.0.0 to another version
+RUN R -e 'remotes::install_github("leeds-cdrc/nutrientprofiler@v1.0.0")'
+```
+
+If the change is not included in a version but rather is the most recent commit
+on the `main` branch, you can change `@v1.0.0` to `@main`, or remove the `@v1.0.0`
+section completely.

--- a/server.R
+++ b/server.R
@@ -519,7 +519,7 @@ shinyServer(function(input, output, session) {
                 req(input$file1)
                 load_and_render(input$file1)
                 }, 
-            editable = 'all', fillContainer=TRUE)
+              fillContainer=TRUE)
 
 
   observeEvent(input$runBulk, {


### PR DESCRIPTION
This PR addresses #7 which asked for more documentation on changes made for the Table Converter.

- Added comments throughout code about what changes do
- Added docstrings to functions
- Added section to README on Table converter and updating `nutrientprofiler` dependency version
- Remove editable options from renderDT (this was not being used and no plans to implement properly)