### PR TITLE
Fix local build and add instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,35 @@ RUN R -e 'remotes::install_github("leeds-cdrc/nutrientprofiler@v1.0.0")'
 If the change is not included in a version but rather is the most recent commit
 on the `main` branch, you can change `@v1.0.0` to `@main`, or remove the `@v1.0.0`
 section completely.
+
+### Building the app locally
+
+Running an app locally is a useful way of testing changes and updates without affecting the live version of the webapp.
+In order to deploy this app locally in your web browser, you will need Docker and a version of git installed (you can use plain [git](https://git-scm.com/), [GitHub CLI](https://cli.github.com/), or [GitHUb Desktop](https://desktop.github.com/)).
+
+After cloning the repository with git and navigating into the folder, from your command line/terminal as a Docker-enabled user:
+
+```bash
+# Build a container using the file "local.dockerfile"
+# -t provides a tag to reference the container later
+docker build -f local.dockerfile . -t npm-calculator
+```
+
+It will take a little while to build the docker image locally.
+
+You can check that this has built locally with the command `docker images`, which should have output similar to this:
+
+```bash
+docker images
+
+REPOSITORY       TAG       IMAGE ID       CREATED              SIZE
+npm-calculator   latest    ID-code-here   About a minute ago   2.2GB
+```
+
+You can then run the docker image and forward the specified port from the container to the host machine you are working on, so that you can view it in a web browser:
+
+```bash
+sudo docker run -p 3838:3838 npm-calculator
+```
+
+Now, visit http://localhost:3838/ to view the local application.

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ section completely.
 ### Building the app locally
 
 Running an app locally is a useful way of testing changes and updates without affecting the live version of the webapp.
-In order to deploy this app locally in your web browser, you will need Docker and a version of git installed (you can use plain [git](https://git-scm.com/), [GitHub CLI](https://cli.github.com/), or [GitHUb Desktop](https://desktop.github.com/)).
+In order to deploy this app locally in your web browser, you will need Docker and a version of git installed (you can use plain [git](https://git-scm.com/), [GitHub CLI](https://cli.github.com/), or [GitHub Desktop](https://desktop.github.com/)).
 
-After cloning the repository with git and navigating into the folder, from your command line/terminal as a Docker-enabled user:
+After cloning the repository with git and navigating into the folder, from your command line/terminal as a Docker-enabled user (with Docker running):
 
 ```bash
 # Build a container using the file "local.dockerfile"
@@ -59,7 +59,9 @@ npm-calculator   latest    ID-code-here   About a minute ago   2.2GB
 You can then run the docker image and forward the specified port from the container to the host machine you are working on, so that you can view it in a web browser:
 
 ```bash
-sudo docker run -p 3838:3838 npm-calculator
+docker run -p 3838:3838 npm-calculator
 ```
 
 Now, visit http://localhost:3838/ to view the local application.
+
+> This local deployment has been tested on Windows, WSL2, and Linux (Ubuntu 22.04).

--- a/local.dockerfile
+++ b/local.dockerfile
@@ -1,0 +1,21 @@
+# Pull the base R Shiny image
+FROM rocker/shiny-verse
+
+# Install R dependencies
+RUN install2.r --error --deps TRUE shinyBS shinythemes shinyjs shinydashboard shinydashboardPlus shinyWidgets remotes
+
+# Install the  nutrientprofiler R package
+RUN R -e 'remotes::install_github("leeds-cdrc/nutrientprofiler@v1.0.0")'
+
+# Copy the Shiny app code to the srv directory
+COPY server.R /srv/shiny-server/server.R
+COPY ui.R /srv/shiny-server/ui.R
+COPY www /srv/shiny-server/www
+COPY R /srv/shiny-server/R
+COPY shiny-server.conf /etc/shiny-server/shiny-server.conf
+
+# Run the app by default
+CMD R -e "shiny::runApp('/srv/shiny-server/', host='0.0.0.0', port=3838)"
+
+# Expose the application port to serve the webapp
+EXPOSE 3838


### PR DESCRIPTION
New dockerfile for lcoal build and additions to the ReadMe:
- Copied across previous dockerfile contents, added comments, added arguments to run the app on spin up, and exposed the port used by the Shiny App to allow port forwarding
- Added basic instructions to the ReadMe to allow the app to be built locally